### PR TITLE
perf(images): add Cloudinary URL transforms and lazy loading

### DIFF
--- a/src/app/components/clubs/club-list/club-list.component.html
+++ b/src/app/components/clubs/club-list/club-list.component.html
@@ -67,8 +67,7 @@
           <ion-card-title>{{ club.clubName }}</ion-card-title>
           <ion-card-subtitle>{{ club.location || 'Location not specified' }}</ion-card-subtitle>
         </div>
-        <img class="club-thumbnail" [src]="club.logoUrl || ('https://picsum.photos/100/100?random=' + (club._id || club.id))"
-          alt="Club Logo" />
+        <ion-img class="club-thumbnail" [src]="club.logoUrl ? (club.logoUrl | cloudinaryUrl:'w_100,h_100,c_fill') : ('https://picsum.photos/100/100?random=' + (club._id || club.id))" alt="Club Logo"></ion-img>
       </div>
 
       <ion-card-content>

--- a/src/app/pages/clubs/club-home/club-home.module.ts
+++ b/src/app/pages/clubs/club-home/club-home.module.ts
@@ -8,6 +8,7 @@ import { ClubHomePageRoutingModule } from './club-home-routing.module';
 import { NetworkIndicatorModule } from '../../../components/network-indicator/network-indicator.module';
 
 import { ClubHomePage } from './club-home.page';
+import { SharedModule } from '../../../shared/shared.module';
 
 @NgModule({
   imports: [
@@ -15,7 +16,8 @@ import { ClubHomePage } from './club-home.page';
     FormsModule,
     IonicModule,
     ClubHomePageRoutingModule,
-    NetworkIndicatorModule
+    NetworkIndicatorModule,
+    SharedModule
   ],
   declarations: [ClubHomePage]
 })

--- a/src/app/pages/clubs/club-home/club-home.page.html
+++ b/src/app/pages/clubs/club-home/club-home.page.html
@@ -33,11 +33,11 @@
   <!-- Actual Header Content -->
   <div *ngIf="!isLoading && !statusLoading" class="club-header-content">
     <div class="cover-photo-container">
-      <img [src]="club.coverPhotoUrl" class="cover-photo" alt="Club Cover Photo" />
+      <img [src]="club.coverPhotoUrl | cloudinaryUrl:'w_800,c_limit'" class="cover-photo" alt="Club Cover Photo" loading="lazy" />
       <div class="gradient-overlay"></div>
     </div>
     <ion-avatar class="club-avatar">
-      <img [src]="club.logoUrl" alt="Club Logo" />
+      <img [src]="club.logoUrl | cloudinaryUrl:'w_80,h_80,c_fill'" alt="Club Logo" loading="lazy" />
     </ion-avatar>
     <div class="header-actions">
       <!-- Admin settings button (separate from join button for better UX) -->
@@ -476,8 +476,7 @@
                 <ion-card-subtitle>{{ getEventTypeDisplay(event.eventType) }} &middot; {{ formatEventDate(event.startTime) }}</ion-card-subtitle>
                 <ion-card-title>{{ event.name }}</ion-card-title>
               </div>
-              <img *ngIf="event.imageUrl" [src]="event.imageUrl" class="club-thumbnail" [alt]="event.name" />
-              <img *ngIf="!event.imageUrl" src="https://placehold.co/200x200/4A5568/FFFFFF?text=EVENT" class="club-thumbnail" [alt]="event.name" />
+              <ion-img [src]="event.imageUrl ? (event.imageUrl | cloudinaryUrl:'w_200,h_200,c_fill') : 'https://placehold.co/200x200/4A5568/FFFFFF?text=EVENT'" class="club-thumbnail" [alt]="event.name"></ion-img>
             </div>
             <ion-card-content *ngIf="event.description" class="event-description">
               <p>{{ event.description }}</p>

--- a/src/app/pages/events/event-detail/event-detail.module.ts
+++ b/src/app/pages/events/event-detail/event-detail.module.ts
@@ -4,9 +4,10 @@ import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 import { EventDetailPageRoutingModule } from './event-detail-routing.module';
 import { EventDetailPage } from './event-detail.page';
+import { SharedModule } from '../../../shared/shared.module';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule, EventDetailPageRoutingModule],
+  imports: [CommonModule, FormsModule, IonicModule, EventDetailPageRoutingModule, SharedModule],
   declarations: [EventDetailPage]
 })
 export class EventDetailPageModule {}

--- a/src/app/pages/events/event-detail/event-detail.page.html
+++ b/src/app/pages/events/event-detail/event-detail.page.html
@@ -62,9 +62,10 @@
       <!-- Background image if available -->
       <img
         *ngIf="event.imageUrl"
-        [src]="event.imageUrl"
+        [src]="event.imageUrl | cloudinaryUrl:'w_800,c_limit'"
         alt="{{ event.name }}"
         class="hero-bg"
+        loading="lazy"
       />
 
       <!-- Gradient overlay (always rendered) -->

--- a/src/app/pages/home/home.module.ts
+++ b/src/app/pages/home/home.module.ts
@@ -14,6 +14,7 @@ import { HomePage } from './home.page';
 import { NotificationBellModule } from '../../components/notification-bell/notification-bell.module';
 import { WeatherWidgetModule } from '../../components/weather-widget/weather-widget.module';
 import { WeatherWidget2Module } from 'src/app/components/weather-widget2/weather-widget2.module';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   imports: [
@@ -24,6 +25,7 @@ import { WeatherWidget2Module } from 'src/app/components/weather-widget2/weather
     NotificationBellModule,
     WeatherWidgetModule,
     WeatherWidget2Module,
+    SharedModule,
   ],
   exports: [HomePage],
   declarations: [HomePage],

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -131,7 +131,7 @@
         [class.mr-6]="last">
         <!-- Logo or initials fallback -->
         <div class="w-20 h-20 rounded-full mx-auto mb-2 border-2 border-slate-500 overflow-hidden flex items-center justify-center bg-slate-600">
-          <img *ngIf="club.logoUrl" [src]="club.logoUrl" [alt]="club.clubName" class="w-full h-full object-cover">
+          <img *ngIf="club.logoUrl" [src]="club.logoUrl | cloudinaryUrl:'w_100,h_100,c_fill'" [alt]="club.clubName" class="w-full h-full object-cover" loading="lazy">
           <span *ngIf="!club.logoUrl" class="text-lg font-bold text-white">{{ getClubInitials(club.clubName) }}</span>
         </div>
         <h4 class="font-bold text-sm leading-tight mb-1">{{ club.clubName }}</h4>

--- a/src/app/pages/me/me.module.ts
+++ b/src/app/pages/me/me.module.ts
@@ -13,6 +13,7 @@ import { MePageRoutingModule } from './me-routing.module';
 import { MePage } from './me.page';
 import { ImageCropperModule } from 'ngx-image-cropper';
 import { LoadingSpinnerModule } from 'src/app/components/utils/loading-spinner/loading-spinner.module';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   imports: [
@@ -23,6 +24,7 @@ import { LoadingSpinnerModule } from 'src/app/components/utils/loading-spinner/l
     MePageRoutingModule,
     ImageCropperModule,
     LoadingSpinnerModule,
+    SharedModule,
   ],
   declarations: [MePage],
   exports: [MePage],

--- a/src/app/pages/me/me.page.html
+++ b/src/app/pages/me/me.page.html
@@ -4,8 +4,8 @@
     <div class="p-6 text-center">
       <input type="file" #fileInput (change)="fileChangeEvent($event)" hidden />
       <ion-button (click)="onProfilePhotoClick()" class="profile-photo-button">
-        <img [src]="user?.profilePhoto || 'https://placehold.co/100x100/F59E0B/2D3748?text='+user?.firstName?.charAt(0)"
-          alt="User Profile Picture" class="w-24 h-24 rounded-full mx-auto mb-4 border-4 border-slate-600">
+        <img [src]="(user?.profilePhoto | cloudinaryUrl:'w_80,h_80,c_fill') || 'https://placehold.co/100x100/F59E0B/2D3748?text='+user?.firstName?.charAt(0)"
+          alt="User Profile Picture" class="w-24 h-24 rounded-full mx-auto mb-4 border-4 border-slate-600" loading="lazy">
       </ion-button>
       <h1 class="text-2xl font-bold font-condensed">{{ user?.username || 'Rider Glenn' }}</h1>
       <p class="text-sm asphalt-muted">Joined {{ user?.createdAt | date }}</p>

--- a/src/app/pages/official-members/official-members.module.ts
+++ b/src/app/pages/official-members/official-members.module.ts
@@ -9,6 +9,7 @@ import { NetworkIndicatorModule } from '../../components/network-indicator/netwo
 import { CsvImportModalComponent } from '../../components/csv-import-modal/csv-import-modal.component';
 
 import { OfficialMembersPage } from './official-members.page';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
   imports: [
@@ -17,7 +18,8 @@ import { OfficialMembersPage } from './official-members.page';
     ReactiveFormsModule,
     IonicModule,
     OfficialMembersPageRoutingModule,
-    NetworkIndicatorModule
+    NetworkIndicatorModule,
+    SharedModule
   ],
   declarations: [OfficialMembersPage, CsvImportModalComponent]
 })

--- a/src/app/pages/official-members/official-members.page.html
+++ b/src/app/pages/official-members/official-members.page.html
@@ -158,7 +158,7 @@
           <!-- Avatar Section -->
           <div class="member-avatar-section">
             <ion-avatar class="member-avatar">
-              <img [src]="getMemberPhoto(member)" [alt]="member.firstName + ' ' + member.lastName">
+              <img [src]="getMemberPhoto(member) | cloudinaryUrl:'w_80,h_80,c_fill'" [alt]="member.firstName + ' ' + member.lastName" loading="lazy">
             </ion-avatar>
             <div class="member-number-badge">
               <span>#{{ member.officialNumber }}</span>

--- a/src/app/pipes/cloudinary-url.pipe.ts
+++ b/src/app/pipes/cloudinary-url.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'cloudinaryUrl'
+})
+export class CloudinaryUrlPipe implements PipeTransform {
+  transform(url: string, transforms: string = ''): string {
+    if (!url || !url.includes('res.cloudinary.com')) return url;
+    const t = transforms ? `${transforms},f_auto,q_auto` : 'f_auto,q_auto';
+    return url.replace('/upload/', `/upload/${t}/`);
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CloudinaryUrlPipe } from '../pipes/cloudinary-url.pipe';
+
+@NgModule({
+  declarations: [CloudinaryUrlPipe],
+  imports: [CommonModule],
+  exports: [CloudinaryUrlPipe, CommonModule]
+})
+export class SharedModule {}

--- a/src/app/tab2/tab2.module.ts
+++ b/src/app/tab2/tab2.module.ts
@@ -7,6 +7,7 @@ import { ExploreContainerComponentModule } from '../explore-container/explore-co
 
 import { Tab2PageRoutingModule } from './tab2-routing.module';
 import { ClubListComponent } from '../components/clubs/club-list/club-list.component';
+import { SharedModule } from '../shared/shared.module';
 
 
 @NgModule({
@@ -15,7 +16,8 @@ import { ClubListComponent } from '../components/clubs/club-list/club-list.compo
     CommonModule,
     FormsModule,
     ExploreContainerComponentModule,
-    Tab2PageRoutingModule
+    Tab2PageRoutingModule,
+    SharedModule
   ],
   // Add ClubListComponent to declarations
   declarations: [Tab2Page, ClubListComponent]


### PR DESCRIPTION
  Introduce CloudinaryUrlPipe to inject resize, f_auto, and q_auto
  transforms into Cloudinary URLs at the upload segment, reducing image
  payload size and enabling WebP delivery where supported.

  Add SharedModule to distribute the pipe across page modules. Switch
  list-view image tags to ion-img for IntersectionObserver-based lazy
  loading, and add loading="lazy" to remaining static image tags.