### PR TITLE
feat(events): add global events with join/leave and paginated feed

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -33,6 +33,11 @@ const routes: Routes = [
     canActivate: [AuthGuard]
   },
   {
+    path: 'events/create-event',
+    loadChildren: () => import('./pages/events/create-event/create-event.module').then( m => m.CreateEventPageModule),
+    canActivate: [AuthGuard]
+  },
+  {
     path: 'clubs/:id',
     loadChildren: () => import('./pages/clubs/club-home/club-home.module').then( m => m.ClubHomePageModule),
     canActivate: [AuthGuard]

--- a/src/app/events/events.page.html
+++ b/src/app/events/events.page.html
@@ -1,10 +1,10 @@
 <ion-header class="asphalt-header">
   <ion-toolbar>
-    <ion-title>My Events</ion-title>
+    <ion-title>Events</ion-title>
   </ion-toolbar>
 </ion-header>
 
-<ion-content class="ion-padding">
+<ion-content>
   <!-- Pull-to-Refresh -->
   <ion-refresher slot="fixed" (ionRefresh)="handleRefresh($event)">
     <ion-refresher-content
@@ -14,8 +14,62 @@
   </ion-refresher>
 
   <div class="content-container">
-    <!-- Loading State -->
-    <div *ngIf="isLoading && !errorMessage">
+
+    <!-- Segment: My Clubs / Global -->
+    <div class="segment-wrap">
+      <ion-segment
+        class="events-segment"
+        [value]="segment"
+        (ionChange)="onSegmentChange($event)">
+        <ion-segment-button value="my-clubs">
+          <ion-label>My Clubs</ion-label>
+        </ion-segment-button>
+        <ion-segment-button value="global">
+          <ion-label>Global</ion-label>
+        </ion-segment-button>
+      </ion-segment>
+    </div>
+
+    <!-- Search -->
+    <div class="search-wrap">
+      <ion-searchbar
+        class="events-searchbar"
+        [value]="s.searchQuery"
+        debounce="400"
+        placeholder="Search events"
+        (ionInput)="onSearchInput($event)">
+      </ion-searchbar>
+    </div>
+
+    <!-- Filter chips -->
+    <div class="filter-chips">
+      <ion-chip
+        class="filter-chip"
+        [class.selected]="s.filter === 'upcoming'"
+        (click)="setFilter('upcoming')">
+        <ion-label>Upcoming</ion-label>
+      </ion-chip>
+      <ion-chip
+        class="filter-chip"
+        [class.selected]="s.filter === 'past'"
+        (click)="setFilter('past')">
+        <ion-label>Past</ion-label>
+      </ion-chip>
+      <ion-chip
+        class="filter-chip"
+        [class.selected]="s.filter === 'all'"
+        (click)="setFilter('all')">
+        <ion-label>All</ion-label>
+      </ion-chip>
+    </div>
+
+    <!-- Results counter -->
+    <div class="results-counter" *ngIf="s.total > 0 && !s.isLoading">
+      {{ s.total }} events
+    </div>
+
+    <!-- Loading State (initial) -->
+    <div *ngIf="s.isLoading && !s.errorMessage">
       <ion-list>
         <ion-card *ngFor="let i of [1, 2, 3]" class="ion-animated ion-fade-in-up asphalt-secondary rounded-xl">
           <ion-skeleton-text animated style="width: 100%; height: 160px;"></ion-skeleton-text>
@@ -38,13 +92,13 @@
     </div>
 
     <!-- Error State -->
-    <div *ngIf="errorMessage && !isLoading" class="ion-text-center ion-padding-top">
+    <div *ngIf="s.errorMessage && !s.isLoading" class="ion-text-center ion-padding-top">
       <ion-card class="asphalt-secondary rounded-xl">
         <ion-card-content>
           <ion-icon name="alert-circle-outline" color="danger" style="font-size: 4em;"></ion-icon>
           <h2>Error Loading Events</h2>
-          <p>{{ errorMessage }}</p>
-          <ion-button expand="block" color="brand-amber" (click)="retryLoadEvents()">
+          <p>{{ s.errorMessage }}</p>
+          <ion-button expand="block" class="amber-btn" (click)="retryLoadEvents()">
             <ion-icon slot="start" name="refresh-outline"></ion-icon>
             Retry
           </ion-button>
@@ -53,8 +107,11 @@
     </div>
 
     <!-- Events List -->
-    <ion-list *ngIf="!isLoading && !errorMessage && events.length > 0">
-      <ion-card *ngFor="let event of events" class="ion-animated ion-fade-in-up asphalt-secondary rounded-xl">
+    <ion-list *ngIf="!s.isLoading && !s.errorMessage && s.events.length > 0">
+      <ion-card
+        *ngFor="let event of s.events; trackBy: trackByEventId"
+        class="ion-animated ion-fade-in-up asphalt-secondary rounded-xl"
+        [routerLink]="['/event', event._id]">
         <img
           [src]="event.imageUrl || 'https://picsum.photos/800/400?random=' + event._id"
           alt="Event Image"
@@ -62,8 +119,13 @@
         <ion-card-header>
           <ion-card-title>{{event.name}}</ion-card-title>
           <ion-card-subtitle>
-            <ion-icon name="business-outline" size="small"></ion-icon>
-            {{getClubName(event.club)}}
+            <ng-container *ngIf="event.scope === 'global'; else clubLine">
+              <span class="global-pill">GLOBAL</span>
+            </ng-container>
+            <ng-template #clubLine>
+              <ion-icon name="business-outline" size="small"></ion-icon>
+              {{getClubName(event.club)}}
+            </ng-template>
           </ion-card-subtitle>
         </ion-card-header>
         <ion-card-content>
@@ -72,12 +134,22 @@
           <div class="event-details">
             <p class="event-time">
               <ion-icon name="calendar-outline" size="small"></ion-icon>
-              {{event.startTime | date:'MMM d, y, h:mm a'}} - {{event.endTime | date:'h:mm a'}}
+              {{event.startTime | date:'MMM d, y, h:mm a'}} <ng-container *ngIf="event.endTime">- {{event.endTime | date:'h:mm a'}}</ng-container>
             </p>
 
             <p class="event-location" *ngIf="event.location">
               <ion-icon name="location-outline" size="small"></ion-icon>
               {{event.location}}
+            </p>
+
+            <p class="event-going" *ngIf="event.attendeeCount !== undefined && event.attendeeCount !== null">
+              <ion-icon name="people-outline" size="small"></ion-icon>
+              <ng-container *ngIf="event.maxAttendees; else uncapped">
+                {{event.attendeeCount}}/{{event.maxAttendees}} going
+              </ng-container>
+              <ng-template #uncapped>
+                {{event.attendeeCount}} going
+              </ng-template>
             </p>
 
             <p class="event-organizer" *ngIf="event.createdBy">
@@ -94,22 +166,60 @@
       </ion-card>
     </ion-list>
 
+    <!-- Infinite Scroll -->
+    <ion-infinite-scroll
+      *ngIf="!s.isLoading && !s.errorMessage && s.events.length > 0"
+      threshold="200px"
+      (ionInfinite)="loadMore()">
+      <ion-infinite-scroll-content
+        loadingSpinner="bubbles"
+        loadingText="Loading more events...">
+      </ion-infinite-scroll-content>
+    </ion-infinite-scroll>
+
     <!-- Empty State -->
-    <div *ngIf="!isLoading && !errorMessage && events.length === 0" class="ion-text-center ion-padding-top">
+    <div *ngIf="!s.isLoading && !s.errorMessage && s.events.length === 0" class="ion-text-center ion-padding-top">
       <ion-card class="asphalt-secondary rounded-xl">
         <ion-card-content>
-          <ion-icon name="calendar-outline" style="font-size: 5em; color: var(--ion-color-medium);"></ion-icon>
-          <h2>No Events Yet</h2>
-          <p>You don't have any upcoming events from your clubs.</p>
-          <p class="ion-margin-top">
-            <small>Events from clubs you're a member of will appear here.</small>
-          </p>
-          <ion-button expand="block" color="brand-amber" routerLink="/clubs" class="ion-margin-top">
-            <ion-icon slot="start" name="people-outline"></ion-icon>
-            Browse Clubs
-          </ion-button>
+          <ion-icon
+            [name]="segment === 'global' ? 'globe-outline' : 'calendar-outline'"
+            style="font-size: 5em; color: var(--ion-color-medium);"></ion-icon>
+          <h2>{{ emptyMessage.title }}</h2>
+          <p>{{ emptyMessage.subtitle }}</p>
+
+          <!-- My Clubs empty (no search, not past): browse clubs -->
+          <ng-container *ngIf="segment === 'my-clubs' && !s.searchQuery && s.filter !== 'past'">
+            <p class="ion-margin-top">
+              <small>Events from clubs you're a member of will appear here.</small>
+            </p>
+            <ion-button
+              expand="block"
+              routerLink="/tabs/clubs"
+              class="ion-margin-top amber-btn">
+              <ion-icon slot="start" name="people-outline"></ion-icon>
+              Browse Clubs
+            </ion-button>
+          </ng-container>
+
+          <!-- Global empty (no search, not past): create one -->
+          <ng-container *ngIf="segment === 'global' && !s.searchQuery && s.filter !== 'past'">
+            <ion-button
+              expand="block"
+              class="ion-margin-top amber-btn"
+              (click)="goToCreateGlobal()">
+              <ion-icon slot="start" name="add-outline"></ion-icon>
+              Create one
+            </ion-button>
+          </ng-container>
         </ion-card-content>
       </ion-card>
     </div>
   </div>
+
+  <!-- FAB: create event -->
+  <ion-fab vertical="bottom" horizontal="end" slot="fixed">
+    <ion-fab-button class="amber-fab" (click)="openCreateActionSheet()">
+      <ion-icon name="add"></ion-icon>
+    </ion-fab-button>
+  </ion-fab>
 </ion-content>

--- a/src/app/events/events.page.scss
+++ b/src/app/events/events.page.scss
@@ -5,8 +5,110 @@
   --asphalt-danger: #EF4444;
   --asphalt-text: #F7FAFC;
   --asphalt-text-muted: #A0AEC0;
-  --ion-background-color: #2D3748;
+
+  --ion-background-color: #1A202C;
   --ion-text-color: #F7FAFC;
+  --ion-card-background: #2D3748;
+  --ion-item-background: #2D3748;
+  --ion-toolbar-background: #2D3748;
+  --ion-toolbar-color: #F7FAFC;
+}
+
+ion-header ion-toolbar {
+  --background: #2D3748;
+  --color: #F7FAFC;
+  --border-color: #4A5568;
+
+  ion-title { color: #F7FAFC; font-weight: 600; }
+  ion-buttons ion-button { --color: #F7FAFC; }
+  ion-back-button { --color: #F7FAFC; }
+}
+
+ion-content { --background: #1A202C; }
+
+// Segment (My Clubs / Global)
+.segment-wrap {
+  padding: 12px 12px 0;
+}
+
+.events-segment {
+  --background: #2D3748;
+  border-radius: 10px;
+  border: 1px solid #4A5568;
+  padding: 4px;
+
+  ion-segment-button {
+    --background: transparent;
+    --background-checked: #F59E0B;
+    --color: #A0AEC0;
+    --color-checked: #000000;
+    --indicator-color: transparent;
+    --border-radius: 8px;
+    min-height: 36px;
+    text-transform: none;
+    font-weight: 600;
+    letter-spacing: 0;
+
+    ion-label { font-size: 0.9rem; }
+  }
+}
+
+// Search + filter chips + counter
+.search-wrap {
+  padding: 8px 8px 0;
+}
+
+.events-searchbar {
+  --background: #2D3748;
+  --color: #F7FAFC;
+  --placeholder-color: #718096;
+  --icon-color: #A0AEC0;
+  --clear-button-color: #A0AEC0;
+  --border-radius: 10px;
+  padding: 0;
+}
+
+.filter-chips {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px 4px;
+  overflow-x: auto;
+
+  &::-webkit-scrollbar { display: none; }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.filter-chip {
+  --background: #2D3748;
+  --color: #F7FAFC;
+  border: 1px solid #4A5568;
+  font-weight: 500;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+  ion-label { color: #F7FAFC; }
+
+  &.selected {
+    --background: #F59E0B;
+    --color: #000000;
+    background: #F59E0B;
+    border-color: #F59E0B;
+
+    ion-label { color: #000000; font-weight: 600; }
+  }
+}
+
+.results-counter {
+  padding: 4px 16px 8px;
+  color: #A0AEC0;
+  font-size: 0.8rem;
+}
+
+.amber-btn {
+  --background: #F59E0B;
+  --background-activated: #d88b0a;
+  --color: #000000;
 }
 
 /* Intentionally left blank to match Tab1 UI */
@@ -327,3 +429,45 @@ ion-card-header {
     }
   }
 }
+
+// "GLOBAL" pill on global-scoped event cards
+.global-pill {
+  display: inline-block;
+  background: #F59E0B;
+  color: #000000;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+// Going / attendees line
+.event-details p.event-going {
+  color: #A0AEC0;
+  font-weight: 500;
+
+  ion-icon { color: #F59E0B; }
+}
+
+// Amber FAB
+ion-fab-button.amber-fab {
+  --background: #F59E0B;
+  --background-activated: #d88b0a;
+  --background-hover: #d88b0a;
+  --color: #000000;
+  --box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+// Dark action sheet styling
+::ng-deep .dark-action-sheet {
+  --background: #2D3748;
+  --color: #F7FAFC;
+  --button-color: #F7FAFC;
+  --button-background-selected: #4A5568;
+
+  .action-sheet-title {
+    color: #A0AEC0 !important;
+  }
+}
+

--- a/src/app/events/events.page.ts
+++ b/src/app/events/events.page.ts
@@ -1,7 +1,29 @@
-import { Component, OnInit } from '@angular/core';
-import { ViewWillEnter } from '@ionic/angular';
-import { ToastController } from '@ionic/angular';
-import { EventService, Event } from '../service/event.service';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import {
+  IonInfiniteScroll,
+  ViewWillEnter,
+  ToastController,
+  ActionSheetController,
+} from '@ionic/angular';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { EventService, Event, PaginatedEventsResponse, MyClubEventsParams } from '../service/event.service';
+import { ClubService } from '../service/club.service';
+
+type EventsFilter = 'upcoming' | 'past' | 'all';
+type EventsSegment = 'my-clubs' | 'global';
+
+interface SegmentState {
+  events: Event[];
+  page: number;
+  total: number;
+  hasMore: boolean;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  errorMessage: string | null;
+  searchQuery: string;
+  filter: EventsFilter;
+}
 
 @Component({
   selector: 'app-events',
@@ -9,64 +31,263 @@ import { EventService, Event } from '../service/event.service';
   styleUrls: ['./events.page.scss'],
 })
 export class EventsPage implements OnInit, ViewWillEnter {
-  events: Event[] = [];
-  isLoading: boolean = false;
-  errorMessage: string | null = null;
+  @ViewChild(IonInfiniteScroll) infiniteScroll?: IonInfiniteScroll;
+
+  segment: EventsSegment = 'my-clubs';
+  limit = 20;
+
+  state: Record<EventsSegment, SegmentState> = {
+    'my-clubs': this.makeInitialState(),
+    'global': this.makeInitialState(),
+  };
+
+  private currentSub?: Subscription;
+  private hasAutoSwitched = false;
+  private hasInitiallyLoaded = false;
 
   constructor(
     private eventService: EventService,
-    private toastController: ToastController
-  ) { }
+    private clubService: ClubService,
+    private toastController: ToastController,
+    private actionSheetCtrl: ActionSheetController,
+    private router: Router,
+  ) {}
+
+  private makeInitialState(): SegmentState {
+    return {
+      events: [],
+      page: 1,
+      total: 0,
+      hasMore: true,
+      isLoading: false,
+      isLoadingMore: false,
+      errorMessage: null,
+      searchQuery: '',
+      filter: 'upcoming',
+    };
+  }
+
+  // Convenience getter for the active segment's state — used heavily by template
+  get s(): SegmentState {
+    return this.state[this.segment];
+  }
 
   ngOnInit() {
-    this.getEvents();
+    this.loadEvents(true);
   }
 
   ionViewWillEnter() {
-    // Reload events when navigating back to the tab
-    this.getEvents();
+    // Only re-fetch active segment so we don't reset the inactive bucket
+    this.loadEvents(true);
   }
 
-  getEvents() {
-    this.isLoading = true;
-    this.errorMessage = null;
+  /**
+   * Central loader. reset=true replaces the active segment's list and resets pagination;
+   * reset=false appends the next page (infinite scroll).
+   */
+  loadEvents(reset: boolean) {
+    if (this.currentSub) {
+      this.currentSub.unsubscribe();
+      this.currentSub = undefined;
+    }
 
-    this.eventService.getMyClubEvents().subscribe({
-      next: (res: Event[]) => {
-        this.events = res;
-        this.isLoading = false;
+    const seg = this.segment;
+    const st = this.state[seg];
+
+    if (reset) {
+      st.page = 1;
+      st.isLoading = true;
+      st.errorMessage = null;
+      if (this.infiniteScroll) {
+        this.infiniteScroll.disabled = false;
+      }
+    } else {
+      st.page += 1;
+      st.isLoadingMore = true;
+    }
+
+    const params: MyClubEventsParams = {
+      page: st.page,
+      limit: this.limit,
+      q: st.searchQuery,
+      filter: st.filter,
+    };
+
+    const obs$ = seg === 'my-clubs'
+      ? this.eventService.getMyClubEvents(params)
+      : this.eventService.getGlobalEvents(params);
+
+    this.currentSub = obs$.subscribe({
+      next: (res: PaginatedEventsResponse) => {
+        // Guard: segment may have switched while in flight
+        if (this.segment !== seg) return;
+
+        if (reset) {
+          st.events = res.events || [];
+        } else {
+          st.events = [...st.events, ...(res.events || [])];
+        }
+        st.total = res.total ?? st.events.length;
+        st.hasMore = !!res.hasMore;
+
+        st.isLoading = false;
+        st.isLoadingMore = false;
+
+        if (this.infiniteScroll) {
+          this.infiniteScroll.complete();
+          if (!st.hasMore) {
+            this.infiniteScroll.disabled = true;
+          }
+        }
+
+        // Auto-switch to global if the user has zero my-clubs events on first ever load
+        if (
+          !this.hasAutoSwitched &&
+          !this.hasInitiallyLoaded &&
+          seg === 'my-clubs' &&
+          reset &&
+          st.filter === 'upcoming' &&
+          !st.searchQuery &&
+          st.events.length === 0
+        ) {
+          this.hasAutoSwitched = true;
+          this.hasInitiallyLoaded = true;
+          this.segment = 'global';
+          this.loadEvents(true);
+          return;
+        }
+        this.hasInitiallyLoaded = true;
       },
       error: (err) => {
-        console.error('Error fetching my club events:', err);
-        this.errorMessage = 'Failed to load events. Please try again.';
-        this.isLoading = false;
-      }
+        if (this.segment !== seg) return;
+        console.error(`Error fetching ${seg} events:`, err);
+        if (!reset && st.page > 1) {
+          st.page -= 1;
+        }
+        if (reset) {
+          st.errorMessage = 'Failed to load events. Please try again.';
+        } else {
+          this.showErrorToast('Failed to load more events');
+        }
+        st.isLoading = false;
+        st.isLoadingMore = false;
+        if (this.infiniteScroll) {
+          this.infiniteScroll.complete();
+        }
+      },
     });
   }
 
-  async handleRefresh(event: any) {
-    try {
-      await this.eventService.getMyClubEvents().toPromise().then((res: Event[] | undefined) => {
-        if (res) {
-          this.events = res;
-        }
-        this.errorMessage = null;
-      });
-    } catch (err) {
-      console.error('Error refreshing events:', err);
-      this.showErrorToast('Failed to refresh events');
-    } finally {
-      event.target.complete();
+  onSegmentChange(ev: any) {
+    const value = ev?.detail?.value as EventsSegment;
+    if (!value || value === this.segment) return;
+    this.segment = value;
+    // Lazy load on first visit, otherwise keep the cached state
+    if (this.state[value].events.length === 0 && !this.state[value].errorMessage) {
+      this.loadEvents(true);
+    } else if (this.infiniteScroll) {
+      this.infiniteScroll.disabled = !this.state[value].hasMore;
     }
   }
 
+  onSearchInput(event: any) {
+    const value: string = event?.detail?.value ?? '';
+    this.s.searchQuery = value;
+    this.loadEvents(true);
+  }
+
+  setFilter(filter: EventsFilter) {
+    if (this.s.filter === filter) return;
+    this.s.filter = filter;
+    this.loadEvents(true);
+  }
+
+  loadMore() {
+    if (!this.s.hasMore || this.s.isLoadingMore) {
+      this.infiniteScroll?.complete();
+      return;
+    }
+    this.loadEvents(false);
+  }
+
+  handleRefresh(event: any) {
+    if (this.currentSub) {
+      this.currentSub.unsubscribe();
+      this.currentSub = undefined;
+    }
+    const seg = this.segment;
+    const st = this.state[seg];
+    st.page = 1;
+    st.errorMessage = null;
+    if (this.infiniteScroll) {
+      this.infiniteScroll.disabled = false;
+    }
+
+    const params: MyClubEventsParams = {
+      page: 1,
+      limit: this.limit,
+      q: st.searchQuery,
+      filter: st.filter,
+    };
+    const obs$ = seg === 'my-clubs'
+      ? this.eventService.getMyClubEvents(params)
+      : this.eventService.getGlobalEvents(params);
+
+    this.currentSub = obs$.subscribe({
+      next: (res: PaginatedEventsResponse) => {
+        if (this.segment !== seg) {
+          event.target.complete();
+          return;
+        }
+        st.events = res.events || [];
+        st.total = res.total ?? st.events.length;
+        st.hasMore = !!res.hasMore;
+        if (this.infiniteScroll && !st.hasMore) {
+          this.infiniteScroll.disabled = true;
+        }
+        event.target.complete();
+      },
+      error: (err) => {
+        console.error('Error refreshing events:', err);
+        this.showErrorToast('Failed to refresh events');
+        event.target.complete();
+      },
+    });
+  }
+
   retryLoadEvents() {
-    this.getEvents();
+    this.loadEvents(true);
+  }
+
+  get emptyMessage(): { title: string; subtitle: string } {
+    const st = this.s;
+    if (st.searchQuery && st.searchQuery.trim().length > 0) {
+      return {
+        title: 'No events match your search',
+        subtitle: 'Try a different keyword or clear the search.',
+      };
+    }
+    if (st.filter === 'past') {
+      return {
+        title: 'No past events',
+        subtitle: 'Past events will appear here.',
+      };
+    }
+    if (this.segment === 'global') {
+      return {
+        title: 'No global events yet',
+        subtitle: 'Be the first to host one for the community.',
+      };
+    }
+    return {
+      title: 'No Events Yet',
+      subtitle: "You don't have any upcoming events from your clubs.",
+    };
   }
 
   private async showErrorToast(message: string) {
     const toast = await this.toastController.create({
-      message: message,
+      message,
       duration: 3000,
       color: 'danger',
       position: 'top',
@@ -74,12 +295,99 @@ export class EventsPage implements OnInit, ViewWillEnter {
     toast.present();
   }
 
+  private async showInfoToast(message: string) {
+    const toast = await this.toastController.create({
+      message,
+      duration: 2500,
+      position: 'top',
+    });
+    toast.present();
+  }
+
+  /**
+   * FAB tap: present an action sheet to choose between a club event and a global event.
+   */
+  async openCreateActionSheet() {
+    const sheet = await this.actionSheetCtrl.create({
+      header: 'Create New Event',
+      cssClass: 'dark-action-sheet',
+      buttons: [
+        {
+          text: 'New Club Event',
+          icon: 'shield-outline',
+          handler: () => {
+            this.startNewClubEvent();
+          },
+        },
+        {
+          text: 'New Global Event',
+          icon: 'globe-outline',
+          handler: () => {
+            this.router.navigate(['/events/create-event'], {
+              queryParams: { scope: 'global' },
+            });
+          },
+        },
+        {
+          text: 'Cancel',
+          role: 'cancel',
+          icon: 'close',
+        },
+      ],
+    });
+    await sheet.present();
+  }
+
+  /**
+   * For a club-scoped event we need a clubId. Fetch the user's clubs:
+   *  - 0  → toast "Join a club first"
+   *  - 1  → navigate straight into create-event for that club
+   *  - 2+ → present a club picker action sheet
+   */
+  private async startNewClubEvent() {
+    try {
+      const res = await this.clubService.getMyClubsPaginated(1, 20).toPromise();
+      const clubs: any[] = (res && (res as any).clubs) || [];
+      if (clubs.length === 0) {
+        this.showInfoToast('Join a club first');
+        return;
+      }
+      if (clubs.length === 1) {
+        const id = clubs[0]?._id;
+        if (id) {
+          this.router.navigate(['/create-event', id]);
+        }
+        return;
+      }
+      const buttons = clubs.slice(0, 10).map((c: any) => ({
+        text: c.clubName || 'Unnamed Club',
+        handler: () => this.router.navigate(['/create-event', c._id]),
+      }));
+      buttons.push({ text: 'Cancel', role: 'cancel' } as any);
+      const sheet = await this.actionSheetCtrl.create({
+        header: 'Pick a Club',
+        cssClass: 'dark-action-sheet',
+        buttons,
+      });
+      await sheet.present();
+    } catch (err) {
+      console.error('Failed to load user clubs:', err);
+      this.showErrorToast('Could not load your clubs');
+    }
+  }
+
+  goToCreateGlobal() {
+    this.router.navigate(['/events/create-event'], {
+      queryParams: { scope: 'global' },
+    });
+  }
+
   /**
    * Get the name of the event creator
-   * @param createdBy - The createdBy field (can be string or populated user object)
-   * @returns The username or name of the creator, or 'Unknown'
    */
-  getCreatorName(createdBy: string | { _id?: string; username?: string; name?: string } | undefined): string {
+  getCreatorName(
+    createdBy: string | { _id?: string; username?: string; name?: string } | undefined
+  ): string {
     if (!createdBy) return 'Unknown';
     if (typeof createdBy === 'string') return 'Unknown';
     return createdBy.username || createdBy.name || 'Unknown';
@@ -87,11 +395,14 @@ export class EventsPage implements OnInit, ViewWillEnter {
 
   /**
    * Get the name of the club
-   * @param club - The club field (can be string or populated club object)
-   * @returns The club name or 'Unknown Club'
    */
-  getClubName(club: string | { _id?: string; clubName?: string }): string {
+  getClubName(club: string | { _id?: string; clubName?: string } | undefined): string {
+    if (!club) return '';
     if (typeof club === 'string') return 'Unknown Club';
     return club.clubName || 'Unknown Club';
+  }
+
+  trackByEventId(_index: number, event: Event): string {
+    return event._id || String(_index);
   }
 }

--- a/src/app/pages/events/create-event/create-event.page.html
+++ b/src/app/pages/events/create-event/create-event.page.html
@@ -7,9 +7,9 @@
 <ion-header class="asphalt-header">
   <ion-toolbar>
     <ion-buttons slot="start">
-      <ion-back-button [defaultHref]="'/clubs/' + clubId"></ion-back-button>
+      <ion-back-button [defaultHref]="isGlobal ? '/tabs/events' : ('/clubs/' + clubId)"></ion-back-button>
     </ion-buttons>
-    <ion-title>Create Event</ion-title>
+    <ion-title>{{ pageTitle }}</ion-title>
     <ion-buttons slot="end">
       <ion-button routerLink="/tabs/home" routerDirection="root" fill="clear">
         <ion-icon slot="icon-only" name="home-outline"></ion-icon>
@@ -76,8 +76,8 @@
         </ion-select>
       </ion-item>
 
-      <!-- Event Privacy Toggle -->
-      <ion-item class="asphalt-input-item privacy-toggle-item" lines="none">
+      <!-- Event Privacy Toggle (club mode only) -->
+      <ion-item *ngIf="!isGlobal" class="asphalt-input-item privacy-toggle-item" lines="none">
         <ion-icon name="eye-outline" slot="start" class="asphalt-icon"></ion-icon>
         <ion-label>
           <h3>Event Visibility</h3>
@@ -92,6 +92,18 @@
           [checked]="true"
           slot="end">
         </ion-toggle>
+      </ion-item>
+
+      <!-- Max attendees (global mode only, optional) -->
+      <ion-item *ngIf="isGlobal" class="asphalt-input-item" lines="none">
+        <ion-icon name="people-outline" slot="start" class="asphalt-icon"></ion-icon>
+        <ion-input
+          formControlName="maxAttendees"
+          type="number"
+          min="1"
+          inputmode="numeric"
+          placeholder="Max attendees (optional, blank = unlimited)">
+        </ion-input>
       </ion-item>
 
       <!-- Start Date & Time -->

--- a/src/app/pages/events/create-event/create-event.page.ts
+++ b/src/app/pages/events/create-event/create-event.page.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { ImageCroppedEvent } from 'ngx-image-cropper';
-import { FormBuilder, FormGroup, FormControl, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ToastController } from '@ionic/angular';
 import { ToastService } from 'src/app/service/utils/toast.service';
-import { EventService, Event as ClubEvent, CreateEventData, Geolocation } from 'src/app/service/event.service';
+import { EventService, Event as ClubEvent, CreateEventData } from 'src/app/service/event.service';
 import { LocationData } from 'src/app/components/mapbox-autocomplete/mapbox-autocomplete.component';
 
 @Component({
@@ -21,7 +21,16 @@ export class CreateEventPage implements OnInit {
   private selectedImageFile: File | null = null;
   isLoading = false;
   clubId: string = '';
+  scope: 'club' | 'global' = 'club';
   selectedLocation: LocationData | null = null;
+
+  get isGlobal(): boolean {
+    return this.scope === 'global';
+  }
+
+  get pageTitle(): string {
+    return this.isGlobal ? 'Create Global Event' : 'Create Event';
+  }
   
   // Date handling
   minDate = new Date().toISOString();
@@ -40,12 +49,13 @@ export class CreateEventPage implements OnInit {
   ) {}
 
   ngOnInit() {
-    // Get clubId from route parameters
+    // Resolve scope from query params first; fall back to club-mode if a clubId param is present.
+    const scopeParam = this.activatedRoute.snapshot.queryParamMap.get('scope');
+    this.scope = scopeParam === 'global' ? 'global' : 'club';
+
     this.clubId = this.activatedRoute.snapshot.paramMap.get('clubId') || '';
-    
-    console.log('CreateEventPage initialized with clubId:', this.clubId);
-    
-    if (!this.clubId) {
+
+    if (!this.isGlobal && !this.clubId) {
       console.warn('No club ID found in route parameters');
       this.toastService.presentToast('No club selected. Please select a club first.', 'top', 3000);
       this.router.navigate(['/tabs/clubs']);
@@ -55,14 +65,15 @@ export class CreateEventPage implements OnInit {
     this.createEventForm = this.formBuilder.group({
       name: ['', [Validators.required, Validators.minLength(3), Validators.maxLength(100)]],
       description: ['', [Validators.required, Validators.minLength(10), Validators.maxLength(1000)]],
-      eventType: ['ride', Validators.required], // Set default to 'ride' for motorcycle clubs
-      location: ['', [Validators.required, Validators.maxLength(200)]], // Direct FormControl
+      eventType: ['ride', Validators.required],
+      location: ['', [Validators.required, Validators.maxLength(200)]],
       startDate: ['', Validators.required],
-      endDate: [''], // Made optional - no validators
-      isPrivate: [true]  // defaults to private
+      endDate: [''],
+      // Global events are always public; force the toggle off in global mode.
+      isPrivate: [this.isGlobal ? false : true],
+      // Global-only optional cap on attendees (empty = unlimited)
+      maxAttendees: [null, [Validators.min(1), Validators.max(100000)]],
     });
-
-    console.log('Form created successfully:', this.createEventForm);
   }
 
   onFileSelected(event: Event): void {
@@ -195,12 +206,21 @@ export class CreateEventPage implements OnInit {
       name: this.createEventForm.get('name')?.value,
       description: this.createEventForm.get('description')?.value,
       startTime: this.startDateTime,
-      endTime: this.endDateTime || undefined, // Only include endTime if provided
+      endTime: this.endDateTime || undefined,
       location: this.createEventForm.get('location')?.value,
       eventType: this.createEventForm.get('eventType')?.value,
-      club: this.clubId,
-      isPrivate: this.createEventForm.get('isPrivate')?.value
+      isPrivate: this.isGlobal ? false : this.createEventForm.get('isPrivate')?.value,
+      scope: this.scope,
     };
+
+    if (this.isGlobal) {
+      const cap = this.createEventForm.get('maxAttendees')?.value;
+      if (cap !== null && cap !== undefined && cap !== '') {
+        eventData.maxAttendees = Number(cap);
+      }
+    } else {
+      eventData.club = this.clubId;
+    }
 
     // Add geolocation data if available from Mapbox selection
     if (this.selectedLocation) {
@@ -313,12 +333,16 @@ export class CreateEventPage implements OnInit {
 
 
   /**
-   * Navigates back to the club home page with the events tab selected
+   * Navigates back to the club home page (or the global events tab if scope=global).
    */
   private navigateToClubHome() {
-    this.router.navigate(['/clubs', this.clubId], { 
+    if (this.isGlobal) {
+      this.router.navigate(['/tabs/events'], { replaceUrl: true });
+      return;
+    }
+    this.router.navigate(['/clubs', this.clubId], {
       queryParams: { tab: 'events' },
-      replaceUrl: true 
+      replaceUrl: true
     });
   }
 }

--- a/src/app/pages/events/event-detail/event-detail.page.html
+++ b/src/app/pages/events/event-detail/event-detail.page.html
@@ -93,6 +93,77 @@
     </div>
     <!-- END HERO -->
 
+    <!-- JOIN / LEAVE BLOCK (global events only) -->
+    <div class="join-block" *ngIf="isGlobal">
+      <!-- Creator -->
+      <ng-container *ngIf="event.isCreator">
+        <span class="hosting-pill">You're hosting</span>
+        <div class="going-line">
+          <ion-icon name="people-outline"></ion-icon>
+          <span *ngIf="!isPast">{{ attendeeCount }} going</span>
+          <span *ngIf="isPast">{{ attendeeCount }} attended</span>
+        </div>
+      </ng-container>
+
+      <!-- Past, non-creator -->
+      <ng-container *ngIf="!event.isCreator && isPast">
+        <div class="going-line">
+          <ion-icon name="people-outline"></ion-icon>
+          <span>{{ attendeeCount }} attended</span>
+        </div>
+      </ng-container>
+
+      <!-- Joined, upcoming -->
+      <ng-container *ngIf="!event.isCreator && !isPast && event.isJoined">
+        <div class="join-row">
+          <button class="joined-btn" disabled>
+            <ion-icon name="checkmark-circle-outline"></ion-icon>
+            Joined
+          </button>
+          <button class="leave-btn" (click)="leaveEvent()" [disabled]="isMutating">Leave</button>
+        </div>
+        <div class="going-line">
+          <ion-icon name="people-outline"></ion-icon>
+          <span>{{ attendeeCount }} going</span>
+        </div>
+      </ng-container>
+
+      <!-- Not joined, upcoming -->
+      <ng-container *ngIf="!event.isCreator && !isPast && !event.isJoined">
+        <button
+          class="join-btn"
+          (click)="joinEvent()"
+          [disabled]="isMutating || isFull">
+          <ion-icon name="people-outline"></ion-icon>
+          {{ isFull ? 'Event is full' : 'Join Event' }}
+        </button>
+        <div class="going-line">
+          <ion-icon name="people-outline"></ion-icon>
+          <span>{{ attendeeCount }} going</span>
+          <span class="spots-left" *ngIf="spotsLeft !== null && spotsLeft > 0">
+            &middot; {{ spotsLeft }} spots left
+          </span>
+        </div>
+      </ng-container>
+
+      <!-- Attendee avatar preview -->
+      <div class="attendee-preview" *ngIf="visibleAttendees.length > 0">
+        <div
+          class="attendee-avatar"
+          *ngFor="let a of visibleAttendees"
+          [title]="a.name || a.username">
+          <img *ngIf="a.profilePicture" [src]="a.profilePicture" alt="" />
+          <span *ngIf="!a.profilePicture" class="initials">{{ attendeeInitials(a) }}</span>
+        </div>
+        <div class="attendee-more" *ngIf="extraAttendees > 0">+{{ extraAttendees }}</div>
+      </div>
+    </div>
+
+    <!-- Hosting badge for club-scoped events (creator only) -->
+    <div class="join-block" *ngIf="!isGlobal && event.isCreator">
+      <span class="hosting-pill">You're hosting</span>
+    </div>
+
     <!-- INFO SECTIONS -->
     <div class="info-section">
 
@@ -169,6 +240,14 @@
       <div class="visibility-row" *ngIf="event.isPrivate !== undefined">
         <ion-icon [name]="event.isPrivate ? 'lock-closed-outline' : 'globe-outline'"></ion-icon>
         <span>{{ event.isPrivate ? 'Private Event' : 'Public Event' }}</span>
+      </div>
+
+      <!-- Delete (creator only) -->
+      <div class="danger-zone" *ngIf="event.isCreator">
+        <button class="delete-btn" (click)="confirmDelete()">
+          <ion-icon name="trash-outline"></ion-icon>
+          Delete Event
+        </button>
       </div>
 
     </div>

--- a/src/app/pages/events/event-detail/event-detail.page.scss
+++ b/src/app/pages/events/event-detail/event-detail.page.scss
@@ -365,3 +365,204 @@ ion-content {
     letter-spacing: 0.04em;
   }
 }
+
+// ============================================================
+// JOIN / LEAVE BLOCK
+// ============================================================
+.join-block {
+  margin: 16px 16px 0;
+  padding: 16px;
+  background: #2D3748;
+  border: 1px solid #4A5568;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .join-btn {
+    width: 100%;
+    background: #F59E0B;
+    color: #000000;
+    font-weight: 700;
+    font-size: 15px;
+    border: none;
+    border-radius: 999px;
+    padding: 14px 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    cursor: pointer;
+    letter-spacing: 0.02em;
+    transition: background 0.15s ease, opacity 0.15s ease;
+
+    ion-icon { font-size: 18px; }
+
+    &:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+  }
+
+  .join-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .joined-btn {
+    flex: 1;
+    background: transparent;
+    color: #10B981;
+    border: 2px solid #10B981;
+    font-weight: 700;
+    font-size: 14px;
+    border-radius: 999px;
+    padding: 12px 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    cursor: default;
+
+    ion-icon { font-size: 18px; }
+  }
+
+  .leave-btn {
+    background: transparent;
+    color: #A0AEC0;
+    border: none;
+    font-weight: 600;
+    font-size: 13px;
+    padding: 10px 14px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+
+    &:hover { color: #F7FAFC; }
+    &:disabled { opacity: 0.5; cursor: not-allowed; }
+  }
+
+  .going-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: #A0AEC0;
+    font-size: 13px;
+    font-weight: 500;
+
+    ion-icon {
+      color: #F59E0B;
+      font-size: 16px;
+    }
+
+    .spots-left {
+      color: #718096;
+    }
+  }
+
+  .hosting-pill {
+    align-self: flex-start;
+    background: #F59E0B;
+    color: #000000;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    padding: 5px 12px;
+    border-radius: 999px;
+    text-transform: uppercase;
+  }
+
+  .attendee-preview {
+    display: flex;
+    align-items: center;
+    gap: -8px;
+    margin-top: 4px;
+
+    .attendee-avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      overflow: hidden;
+      border: 2px solid #2D3748;
+      background: #4A5568;
+      margin-left: -8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+
+      &:first-child { margin-left: 0; }
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .initials {
+        color: #F7FAFC;
+        font-size: 11px;
+        font-weight: 700;
+      }
+    }
+
+    .attendee-more {
+      margin-left: 6px;
+      color: #A0AEC0;
+      font-size: 12px;
+      font-weight: 600;
+    }
+  }
+}
+
+// ============================================================
+// DELETE BUTTON (creator only, danger zone)
+// ============================================================
+.danger-zone {
+  margin-top: 24px;
+
+  .delete-btn {
+    width: 100%;
+    background: transparent;
+    color: #EF4444;
+    border: 1.5px solid #EF4444;
+    border-radius: 10px;
+    padding: 12px 18px;
+    font-weight: 700;
+    font-size: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    cursor: pointer;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: background 0.15s ease, color 0.15s ease;
+
+    ion-icon { font-size: 16px; }
+
+    &:hover {
+      background: #EF4444;
+      color: #ffffff;
+    }
+  }
+}
+
+// Dark alert styling override
+::ng-deep .dark-alert {
+  --background: #2D3748;
+
+  .alert-wrapper {
+    background: #2D3748 !important;
+    border: 1px solid #4A5568;
+  }
+  .alert-title,
+  .alert-message {
+    color: #F7FAFC !important;
+  }
+  .alert-button {
+    color: #F59E0B !important;
+  }
+}
+

--- a/src/app/pages/events/event-detail/event-detail.page.ts
+++ b/src/app/pages/events/event-detail/event-detail.page.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { NavController } from '@ionic/angular';
-import { EventService, Event as AppEvent } from 'src/app/service/event.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NavController, AlertController, ToastController } from '@ionic/angular';
+import { EventService, Event as AppEvent, EventAttendee } from 'src/app/service/event.service';
 
 @Component({
   selector: 'app-event-detail',
@@ -12,11 +12,15 @@ export class EventDetailPage implements OnInit {
   event: AppEvent | null = null;
   isLoading = true;
   error: string | null = null;
+  isMutating = false;
 
   constructor(
     private route: ActivatedRoute,
     private navCtrl: NavController,
-    private eventService: EventService
+    private router: Router,
+    private eventService: EventService,
+    private alertCtrl: AlertController,
+    private toastCtrl: ToastController,
   ) {}
 
   ngOnInit() {
@@ -27,7 +31,7 @@ export class EventDetailPage implements OnInit {
           this.event = event;
           this.isLoading = false;
         },
-        error: (err) => {
+        error: (_err) => {
           this.error = 'Could not load event details.';
           this.isLoading = false;
         }
@@ -60,6 +64,144 @@ export class EventDetailPage implements OnInit {
     if (start < now && startDate !== todayDate) return 'past';
     if (startDate === todayDate) return 'today';
     return 'upcoming';
+  }
+
+  get isPast(): boolean {
+    return this.getEventStatus() === 'past';
+  }
+
+  get isGlobal(): boolean {
+    return this.event?.scope === 'global';
+  }
+
+  get attendeeCount(): number {
+    return this.event?.attendeeCount ?? 0;
+  }
+
+  get isFull(): boolean {
+    if (!this.event?.maxAttendees) return false;
+    return this.attendeeCount >= this.event.maxAttendees;
+  }
+
+  get spotsLeft(): number | null {
+    if (!this.event?.maxAttendees) return null;
+    return Math.max(0, this.event.maxAttendees - this.attendeeCount);
+  }
+
+  get visibleAttendees(): EventAttendee[] {
+    return (this.event?.attendees || []).slice(0, 8);
+  }
+
+  get extraAttendees(): number {
+    const total = this.attendeeCount;
+    const shown = this.visibleAttendees.length;
+    return Math.max(0, total - shown);
+  }
+
+  attendeeInitials(a: EventAttendee): string {
+    const src = a.name || a.username || '';
+    const parts = src.trim().split(/\s+/).slice(0, 2);
+    return parts.map(p => p[0] || '').join('').toUpperCase() || '?';
+  }
+
+  async joinEvent() {
+    if (!this.event?._id || this.isMutating) return;
+    if (this.isFull) return;
+
+    this.isMutating = true;
+    // Optimistic update
+    const prev = { isJoined: this.event.isJoined, attendeeCount: this.event.attendeeCount };
+    this.event.isJoined = true;
+    this.event.attendeeCount = (this.event.attendeeCount ?? 0) + 1;
+
+    this.eventService.joinEvent(this.event._id).subscribe({
+      next: (updated) => {
+        if (this.event) {
+          if (updated.attendeeCount !== undefined) this.event.attendeeCount = updated.attendeeCount;
+          if (updated.isJoined !== undefined) this.event.isJoined = updated.isJoined;
+        }
+        this.isMutating = false;
+      },
+      error: (err) => {
+        console.error('Failed to join event:', err);
+        if (this.event) {
+          this.event.isJoined = prev.isJoined;
+          this.event.attendeeCount = prev.attendeeCount;
+        }
+        this.isMutating = false;
+        this.showToast('Could not join event', 'danger');
+      }
+    });
+  }
+
+  async leaveEvent() {
+    if (!this.event?._id || this.isMutating) return;
+
+    this.isMutating = true;
+    const prev = { isJoined: this.event.isJoined, attendeeCount: this.event.attendeeCount };
+    this.event.isJoined = false;
+    this.event.attendeeCount = Math.max(0, (this.event.attendeeCount ?? 0) - 1);
+
+    this.eventService.leaveEvent(this.event._id).subscribe({
+      next: (updated) => {
+        if (this.event) {
+          if (updated.attendeeCount !== undefined) this.event.attendeeCount = updated.attendeeCount;
+          if (updated.isJoined !== undefined) this.event.isJoined = updated.isJoined;
+        }
+        this.isMutating = false;
+      },
+      error: (err) => {
+        console.error('Failed to leave event:', err);
+        if (this.event) {
+          this.event.isJoined = prev.isJoined;
+          this.event.attendeeCount = prev.attendeeCount;
+        }
+        this.isMutating = false;
+        this.showToast('Could not leave event', 'danger');
+      }
+    });
+  }
+
+  async confirmDelete() {
+    if (!this.event?._id) return;
+    const alert = await this.alertCtrl.create({
+      header: 'Delete Event?',
+      message: 'Delete this event? This cannot be undone.',
+      cssClass: 'dark-alert',
+      buttons: [
+        { text: 'Cancel', role: 'cancel' },
+        {
+          text: 'Delete',
+          role: 'destructive',
+          handler: () => this.deleteEvent(),
+        },
+      ],
+    });
+    await alert.present();
+  }
+
+  private deleteEvent() {
+    if (!this.event?._id) return;
+    this.eventService.deleteEvent(this.event._id).subscribe({
+      next: () => {
+        this.showToast('Event deleted', 'success');
+        this.router.navigate(['/tabs/events'], { replaceUrl: true });
+      },
+      error: (err) => {
+        console.error('Failed to delete event:', err);
+        this.showToast('Could not delete event', 'danger');
+      },
+    });
+  }
+
+  private async showToast(message: string, color: 'success' | 'danger' = 'success') {
+    const t = await this.toastCtrl.create({
+      message,
+      duration: 2500,
+      color,
+      position: 'top',
+    });
+    t.present();
   }
 
   getEventTypeLabel(type: string): string {

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -126,9 +126,10 @@
     <div *ngIf="!nearbyClubsLoading && nearbyClubs.length > 0" class="flex overflow-x-auto no-scrollbar pl-6">
       <div
         *ngFor="let club of nearbyClubs; let last = last"
-        class="flex-shrink-0 w-48 text-center asphalt-secondary rounded-xl p-4"
+        class="flex-shrink-0 w-48 text-center asphalt-secondary rounded-xl p-4 cursor-pointer"
         [class.mr-4]="!last"
-        [class.mr-6]="last">
+        [class.mr-6]="last"
+        (click)="viewClubDetails(club._id)">
         <!-- Logo or initials fallback -->
         <div class="w-20 h-20 rounded-full mx-auto mb-2 border-2 border-slate-500 overflow-hidden flex items-center justify-center bg-slate-600">
           <img *ngIf="club.logoUrl" [src]="club.logoUrl | cloudinaryUrl:'w_100,h_100,c_fill'" [alt]="club.clubName" class="w-full h-full object-cover" loading="lazy">

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -70,13 +70,9 @@ export class HomePage implements OnInit {
 
   loadNextRide() {
     this.nextRideLoading = true;
-    this.eventService.getMyClubEvents().subscribe({
-      next: (events) => {
-        const now = new Date();
-        const upcoming = events
-          .filter(e => new Date(e.startTime) > now)
-          .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
-        this.nextRide = upcoming.length > 0 ? upcoming[0] : null;
+    this.eventService.getMyClubEvents({ filter: 'upcoming', page: 1, limit: 1 }).subscribe({
+      next: (res) => {
+        this.nextRide = res.events.length > 0 ? res.events[0] : null;
         this.nextRideLoading = false;
       },
       error: (err) => {
@@ -121,6 +117,10 @@ export class HomePage implements OnInit {
 
   viewEventDetails(eventId: string) {
     this.router.navigate(['/event', eventId]);
+  }
+
+  viewClubDetails(clubId: string) {
+    this.router.navigate(['/clubs', clubId]);
   }
 
 }

--- a/src/app/service/event.service.ts
+++ b/src/app/service/event.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, BehaviorSubject } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { throwError } from 'rxjs';
@@ -12,6 +12,14 @@ export interface Geolocation {
   placeName: string;
 }
 
+// Lightweight attendee representation returned by the detail endpoint
+export interface EventAttendee {
+  _id: string;
+  username?: string;
+  name?: string;
+  profilePicture?: string;
+}
+
 // Event interface matching the backend EventModel structure
 export interface Event {
   _id?: string;
@@ -22,13 +30,39 @@ export interface Event {
   location?: string;
   geolocation?: Geolocation;
   eventType: 'ride' | 'meeting' | 'meetup' | 'event';
-  club: string | { _id?: string; clubName?: string }; // Can be ObjectId or populated club object
+  club?: string | { _id?: string; clubName?: string }; // Optional: not present for global events
   createdBy?: string | { _id?: string; username?: string; name?: string }; // Can be ObjectId or populated user object
   imageUrl?: string;
   imagePublicId?: string;
   isPrivate?: boolean;
   createdAt?: Date | string;
   updatedAt?: Date | string;
+
+  // Global events / join state additions
+  scope?: 'club' | 'global';
+  attendeeCount?: number;
+  maxAttendees?: number | null;
+  isJoined?: boolean;
+  isCreator?: boolean;
+  joinPolicy?: 'instant';
+  attendees?: EventAttendee[];
+}
+
+// Paginated events response for the "my clubs" feed
+export interface PaginatedEventsResponse {
+  events: Event[];
+  page: number;
+  limit: number;
+  total: number;
+  hasMore: boolean;
+}
+
+// Query parameters accepted by getMyClubEvents
+export interface MyClubEventsParams {
+  page?: number;
+  limit?: number;
+  q?: string;
+  filter?: 'upcoming' | 'past' | 'all';
 }
 
 // Event creation data interface
@@ -40,8 +74,10 @@ export interface CreateEventData {
   location?: string;
   geolocation?: Geolocation;
   eventType: 'ride' | 'meeting' | 'meetup' | 'event';
-  club: string;
+  club?: string; // Optional: omitted for global events
   isPrivate?: boolean;
+  scope?: 'club' | 'global';
+  maxAttendees?: number | null;
 }
 
 @Injectable({
@@ -109,9 +145,11 @@ export class EventService {
   createEvent(eventData: CreateEventData): Observable<Event> {
     return this.http.post<Event>(`${this.baseUrl}/create`, eventData)
       .pipe(
-        tap(newEvent => {
-          // Refresh the club's events after creating a new event
-          this.refreshClubEvents(eventData.club);
+        tap(_newEvent => {
+          // Refresh the club's events after creating a new club-scoped event
+          if (eventData.club) {
+            this.refreshClubEvents(eventData.club);
+          }
         }),
         catchError(error => {
           console.error('Error creating event:', error);
@@ -154,11 +192,24 @@ export class EventService {
   }
 
   /**
-   * Get events from clubs the user is a member of
-   * @returns Observable with the events data from user's clubs
+   * Get paginated events from clubs the user is a member of.
+   * Supports search (q), time filter, and pagination.
    */
-  getMyClubEvents(): Observable<Event[]> {
-    return this.http.get<Event[]>(`${this.baseUrl}/my-clubs`)
+  getMyClubEvents(params: MyClubEventsParams = {}): Observable<PaginatedEventsResponse> {
+    const { page = 1, limit = 20, q = '', filter = 'upcoming' } = params;
+
+    let httpParams = new HttpParams()
+      .set('page', String(page))
+      .set('limit', String(limit))
+      .set('filter', filter);
+
+    const trimmed = q.trim();
+    if (trimmed.length > 0) {
+      httpParams = httpParams.set('q', trimmed);
+    }
+
+    return this.http
+      .get<PaginatedEventsResponse>(`${this.baseUrl}/my-clubs`, { params: httpParams })
       .pipe(
         catchError(error => {
           console.error('Error fetching my club events:', error);
@@ -210,18 +261,72 @@ export class EventService {
   /**
    * Delete an event
    * @param eventId - The ID of the event to delete
-   * @param clubId - The ID of the club (needed to refresh the events list)
+   * @param clubId - Optional club ID (refreshes club events list if provided)
    * @returns Observable with the deletion result
    */
-  deleteEvent(eventId: string, clubId: string): Observable<any> {
-    return this.http.delete(`${this.baseUrl}/${eventId}`)
+  deleteEvent(eventId: string, clubId?: string): Observable<{ success: boolean }> {
+    return this.http.delete<{ success: boolean }>(`${this.baseUrl}/${eventId}`)
       .pipe(
         tap(() => {
-          // Refresh the club's events after deletion
-          this.refreshClubEvents(clubId);
+          if (clubId) {
+            this.refreshClubEvents(clubId);
+          }
         }),
         catchError(error => {
           console.error('Error deleting event:', error);
+          return throwError(() => error);
+        })
+      );
+  }
+
+  /**
+   * Get paginated global events feed.
+   * Mirrors getMyClubEvents but hits /global.
+   */
+  getGlobalEvents(params: MyClubEventsParams = {}): Observable<PaginatedEventsResponse> {
+    const { page = 1, limit = 20, q = '', filter = 'upcoming' } = params;
+
+    let httpParams = new HttpParams()
+      .set('page', String(page))
+      .set('limit', String(limit))
+      .set('filter', filter);
+
+    const trimmed = q.trim();
+    if (trimmed.length > 0) {
+      httpParams = httpParams.set('q', trimmed);
+    }
+
+    return this.http
+      .get<PaginatedEventsResponse>(`${this.baseUrl}/global`, { params: httpParams })
+      .pipe(
+        catchError(error => {
+          console.error('Error fetching global events:', error);
+          return throwError(() => error);
+        })
+      );
+  }
+
+  /**
+   * Join an event (instant-join only in v1).
+   */
+  joinEvent(eventId: string): Observable<Partial<Event>> {
+    return this.http.post<Partial<Event>>(`${this.baseUrl}/${eventId}/join`, {})
+      .pipe(
+        catchError(error => {
+          console.error('Error joining event:', error);
+          return throwError(() => error);
+        })
+      );
+  }
+
+  /**
+   * Leave an event the user has previously joined.
+   */
+  leaveEvent(eventId: string): Observable<Partial<Event>> {
+    return this.http.post<Partial<Event>>(`${this.baseUrl}/${eventId}/leave`, {})
+      .pipe(
+        catchError(error => {
+          console.error('Error leaving event:', error);
           return throwError(() => error);
         })
       );


### PR DESCRIPTION
  - Add global event scope alongside club-scoped events with instant-join and an optional max-attendees cap
  - Paginate /my-clubs and add a /global feed with search and upcoming/past/all filter
  - Events tab: My Clubs / Global segment, search bar, filter action sheet, infinite scroll, and auto-switch to Global when the user has no club events
  - Event detail: join/leave with optimistic updates, attendee avatars, spots-left, and creator delete confirmation
  - Create event: support ?scope=global (no clubId), show max-attendees input, force public visibility, and adapt title / back nav
  - Add standalone /events/create-event route for global creation
  - Home: make "Clubs Near You" cards navigate to the club page and update nextRide to the new paginated API signature