### PR TITLE
feat: make event cards on club page navigate to event detail

### DIFF
--- a/src/app/pages/clubs/club-home/club-home.page.html
+++ b/src/app/pages/clubs/club-home/club-home.page.html
@@ -470,7 +470,7 @@
 
         <!-- Events List -->
         <div *ngIf="!eventsLoading && !eventsError && clubEvents.length > 0" class="events-section">
-          <ion-card class="asphalt-card" *ngFor="let event of clubEvents">
+          <ion-card class="asphalt-card event-card" *ngFor="let event of clubEvents" (click)="navigateToEvent(event._id)" role="button" tabindex="0">
             <div class="card-header-row">
               <div class="card-text">
                 <ion-card-subtitle>{{ getEventTypeDisplay(event.eventType) }} &middot; {{ formatEventDate(event.startTime) }}</ion-card-subtitle>

--- a/src/app/pages/clubs/club-home/club-home.page.scss
+++ b/src/app/pages/clubs/club-home/club-home.page.scss
@@ -1397,6 +1397,18 @@ ion-action-sheet.dark-theme-action-sheet {
   padding-top: 0;
 }
 
+/* Clickable event card — tap feedback + pointer on hover */
+.event-card {
+  cursor: pointer;
+  outline: none;
+  transition: transform 0.12s ease, opacity 0.12s ease;
+
+  &:active {
+    transform: scale(0.98);
+    opacity: 0.9;
+  }
+}
+
 /* --- MEMBERS MODAL STYLES --- */
 
 // Enhanced section header styling with manage button

--- a/src/app/pages/clubs/club-home/club-home.page.ts
+++ b/src/app/pages/clubs/club-home/club-home.page.ts
@@ -2072,6 +2072,17 @@ export class ClubHomePage implements OnInit, OnDestroy, ViewWillEnter {
   }
 
   /**
+   * Navigate to event detail page
+   */
+  navigateToEvent(eventId: string | undefined) {
+    if (!eventId) {
+      this.presentToast('Unable to open event: Event ID not available', 'danger');
+      return;
+    }
+    this.router.navigate(['/event', eventId]);
+  }
+
+  /**
    * Navigate to edit club page with current club ID
    */
   async navigateToEditClub() {


### PR DESCRIPTION
Add click handler to event ion-card on the club-home events tab that routes to /event/:id. Includes a navigateToEvent method with an error toast fallback and tap-feedback styling on the card.