### PR TITLE
chore(cli): disable Angular CLI analytics

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -153,7 +153,10 @@
     }
   },
   "cli": {
-    "schematicCollections": ["@ionic/angular-toolkit"]
+    "schematicCollections": [
+      "@ionic/angular-toolkit"
+    ],
+    "analytics": false
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {


### PR DESCRIPTION
Set "analytics": false under the "cli" block to suppress the analytics prompt when running ng generate / ng commands.